### PR TITLE
add social link to discuss.okfn.or

### DIFF
--- a/header.php
+++ b/header.php
@@ -36,7 +36,8 @@
       </div>
       <nav id="header-nav" role="navigation" class="hidden-xs">
         <div id="nav-social" class="social-links">
-        <a class="facebook" href="https://www.facebook.com/<?php echo get_option('okfnwp_fb_id', 'OKFNetwork'); ?>"><i class="fa fa-facebook fa-lg"></i></a>
+          <a class="facebook" href="https://discuss.okfn.org/<?php echo get_option('okfnwp_discuss_id', 'OKFNetwork'); ?>"><i class="fa fa-comment-o fa-lg"></i></a>
+          <a class="facebook" href="https://www.facebook.com/<?php echo get_option('okfnwp_fb_id', 'OKFNetwork'); ?>"><i class="fa fa-facebook fa-lg"></i></a>
           <a class="twitter" href="https://twitter.com/<?php echo get_option('okfnwp_twitter_id', 'okfn'); ?>"><i class="fa fa-twitter fa-lg"></i></a>
         </div>
       </nav>

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -29,6 +29,12 @@ $options = array(
     "type" => "text"
   ),
   array(
+    "name" => "Discuss Page",
+    "desc" => "discuss.okfn.org page name. If the URL to your page is https://discuss.okfn.org/c/local-groups/okbr, then use c/local-groups/okbr",
+    "id"   => $shortname . "_discuss_id",
+    "type" => "text"
+  ),
+  array(
     "name" => "Twitter Handle",
     "desc" => "Twitter handle to link to. Example: If your handle is @okfn, use okfn",
     "id"   => $shortname . "_twitter_id",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "okfn-wp",
-	"title": "Open Knowledge WordPress Theme",
+	"name": "okfn-wp2",
+	"title": "Open Knowledge WordPress Theme2",
 	"description": "",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"author": {
 	},
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "okfn-wp",
 	"title": "Open Knowledge WordPress Theme",
 	"description": "",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"author": {
 	},
 	"repository": {


### PR DESCRIPTION
Add an icon in the *header-nav* superior bar, linking to appropriate folder at [discuss.okfn.org](https://discuss.okfn.org). For administrator, at `theme-options.php` page, add the "Discuss Page" field.

